### PR TITLE
Remove jemalloc - main should do this

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ itertools = "0.10.5"
 num = { version = "0.4.0", default-features = false }
 serde = "1.0.152"
 serde_with = { version = "2.2.0", features = ["hex"] }
-jemallocator = "0.5.0"
 rayon = { version = "1.5.3" }
 hex = { version = "0.4.3" }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
-// use jemallocator as recommended by plonky2
 extern crate alloc;
-use jemallocator::Jemalloc;
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
 
 pub mod hash;
 pub mod nonnative;


### PR DESCRIPTION
The binary has to replace the global allocator, not libraries. Otherwise there are linker errors.