### PR TITLE
Gadgets for sha256 merkle proofs/delta merkle proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# for mac
+.DS_Store
+
+# Do not include rust-toolchain.toml (users can choose their own nightly channel)
+rust-toolchain.toml

--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ cargo test --release -- --nocapture
 
 Hash functions:
 - [x] Sha256
+    * [x] Hash Arbitrary Length Data
+    * [x] Hash Two to One (For use with Merkle Proofs)
+    * [x] Merkle Proof Gadget
+    * [x] Delta Merkle Proof Gadget
 - [x] Keccak256
+    * [x] Hash Arbitrary Length Data
+    * [ ] Hash Two to One (For use with Merkle Proofs)
+    * [ ] Merkle Proof Gadget
+    * [ ] Delta Merkle Proof Gadget
 
 Integer arithmetic:
 - [x] Uint32 arithmetic ops (add, mul, ...)

--- a/src/hash/merkle_utils.rs
+++ b/src/hash/merkle_utils.rs
@@ -1,0 +1,120 @@
+use plonky2::hash::hash_types::RichField;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use super::{sha256::WitnessHashSha2, sha256_merkle::{MerkleProofSha256Gadget, DeltaMerkleProofSha256Gadget}, WitnessHash};
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Copy)]
+pub struct Hash256(#[serde_as(as = "serde_with::hex::Hex")] pub [u8; 32]);
+
+impl Hash256 {
+    pub fn from_str(s: &str) -> Result<Self, ()> {
+        let bytes = hex::decode(s).unwrap();
+        assert_eq!(bytes.len(), 32);
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes);
+        Ok(Self(array))
+    }
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
+pub struct MerkleProof<Hash: PartialEq> {
+    pub root: Hash,
+    pub value: Hash,
+
+    pub index: u64,
+    pub siblings: Vec<Hash>,
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
+pub struct DeltaMerkleProof<Hash: PartialEq> {
+    pub old_root: Hash,
+    pub old_value: Hash,
+
+    pub new_root: Hash,
+    pub new_value: Hash,
+
+    pub index: u64,
+    pub siblings: Vec<Hash>,
+}
+
+pub trait MerkleHasher<Hash: PartialEq> {
+    fn two_to_one(&self, left: &Hash, right: &Hash) -> Hash;
+}
+
+pub fn verify_merkle_proof<Hash: PartialEq, Hasher: MerkleHasher<Hash>>(
+    hasher: &Hasher,
+    proof: MerkleProof<Hash>,
+) -> bool {
+    let mut current = proof.value;
+    for (i, sibling) in proof.siblings.iter().enumerate() {
+        if proof.index & (1 << i) == 0 {
+            current = hasher.two_to_one(sibling, &current);
+        } else {
+            current = hasher.two_to_one(sibling, &current);
+        }
+    }
+    current == proof.root
+}
+pub fn verify_delta_merkle_proof<Hash: PartialEq, Hasher: MerkleHasher<Hash>>(
+    hasher: &Hasher,
+    proof: DeltaMerkleProof<Hash>,
+) -> bool {
+    let mut current = proof.old_value;
+    for (i, sibling) in proof.siblings.iter().enumerate() {
+        if proof.index & (1 << i) == 0 {
+            current = hasher.two_to_one(sibling, &current);
+        } else {
+            current = hasher.two_to_one(sibling, &current);
+        }
+    }
+    if current != proof.old_root {
+        return false;
+    }
+    current = proof.new_value;
+    for (i, sibling) in proof.siblings.iter().enumerate() {
+        if proof.index & (1 << i) == 0 {
+            current = hasher.two_to_one(sibling, &current);
+        } else {
+            current = hasher.two_to_one(sibling, &current);
+        }
+    }
+    current == proof.new_root
+}
+
+pub type MerkleProof256 = MerkleProof<Hash256>;
+pub type DeltaMerkleProof256 = DeltaMerkleProof<Hash256>;
+
+impl MerkleProofSha256Gadget {
+    pub fn set_witness_from_proof<F: RichField, W: WitnessHashSha2<F>>(
+        &self,
+        witness: &mut W,
+        merkle_proof: &MerkleProof256,
+    ) {
+        witness.set_hash256_target(&self.value, &merkle_proof.value.0);
+        witness.set_target(self.index, F::from_noncanonical_u64(merkle_proof.index));
+        for (i, sibling) in self.siblings.iter().enumerate() {
+            witness.set_hash256_target(sibling, &merkle_proof.siblings[i].0);
+        }
+    }
+}
+
+
+
+impl DeltaMerkleProofSha256Gadget {
+    pub fn set_witness_from_proof<F: RichField, W: WitnessHashSha2<F>>(
+        &self,
+        witness: &mut W,
+        merkle_proof: &DeltaMerkleProof256,
+    ) {
+        witness.set_hash256_target(&self.old_value, &merkle_proof.old_value.0);
+        witness.set_hash256_target(&self.new_value, &merkle_proof.new_value.0);
+        witness.set_target(self.index, F::from_noncanonical_u64(merkle_proof.index));
+        for (i, sibling) in self.siblings.iter().enumerate() {
+            witness.set_hash256_target(sibling, &merkle_proof.siblings[i].0);
+        }
+    }
+}

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -3,3 +3,5 @@ pub mod sha256;
 pub mod types;
 
 pub use types::*;
+pub mod merkle_utils;
+pub mod sha256_merkle;

--- a/src/hash/sha256.rs
+++ b/src/hash/sha256.rs
@@ -10,6 +10,8 @@ use crate::hash::{HashInputTarget, HashOutputTarget, WitnessHash};
 use crate::u32::arithmetic_u32::{CircuitBuilderU32, U32Target};
 use crate::u32::interleaved_u32::CircuitBuilderB32;
 
+use super::Hash256Target;
+
 pub trait WitnessHashSha2<F: PrimeField64>: Witness<F> {
     fn set_sha256_input_target(&mut self, target: &HashInputTarget, value: &[u8]);
     fn set_sha256_output_target(&mut self, target: &HashOutputTarget, value: &[u8]);
@@ -44,6 +46,7 @@ pub trait CircuitBuilderHashSha2<F: RichField + Extendable<D>, const D: usize> {
 
     fn hash_sha256(&mut self, hash: &HashInputTarget) -> HashOutputTarget;
     fn sha256_input_padding(&mut self, target: &HashInputTarget, padding_len: u64);
+    fn two_to_one_sha256(&mut self, left: Hash256Target, right: Hash256Target) -> Hash256Target;
 }
 
 /// Initial state for SHA-256.
@@ -243,6 +246,159 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderHashSha2<F, D>
         }
         output
     }
+
+    // https://en.wikipedia.org/wiki/SHA-2#Pseudocode
+    fn two_to_one_sha256(&mut self, left: Hash256Target, right: Hash256Target) -> Hash256Target {
+        let mut state: Hash256Target = [
+            self.constant_u32(H256_256[0]),
+            self.constant_u32(H256_256[1]),
+            self.constant_u32(H256_256[2]),
+            self.constant_u32(H256_256[3]),
+            self.constant_u32(H256_256[4]),
+            self.constant_u32(H256_256[5]),
+            self.constant_u32(H256_256[6]),
+            self.constant_u32(H256_256[7]),
+        ];
+
+        // Initialize array of round constants:
+        // (first 32 bits of the fractional parts of the cube roots of the first 64 primes 2..311)
+        let mut k256 = Vec::new();
+        for item in &K32 {
+            k256.push(self.constant_u32(*item));
+        }
+
+        // Pre-processing (Padding)
+        // Padding is done by the Witness when setting the input value to the target
+
+        // Process the 512-bit message
+        let mut w: [U32Target; 16] = [
+            left[0], left[1], left[2], left[3], left[4], left[5], left[6], left[7], right[0],
+            right[1], right[2], right[3], right[4], right[5], right[6], right[7],
+        ];
+
+        // Initialize working variables to current hash value
+        let mut a = state[0];
+        let mut b = state[1];
+        let mut c = state[2];
+        let mut d = state[3];
+        let mut e = state[4];
+        let mut f = state[5];
+        let mut g = state[6];
+        let mut h = state[7];
+
+        for i in 0..64 {
+            // Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array
+            if i >= 16 {
+                let s0 = sigma(self, w[(i + 1) & 0xf], 7, 18, 3);
+                let s1 = sigma(self, w[(i + 14) & 0xf], 17, 19, 10);
+                w[i & 0xf] = self.add_many_u32(&[s0, s1, w[(i + 9) & 0xf], w[i & 0xf]]).0;
+            }
+
+            // Compression function main loop
+            let big_s1_e = big_sigma(self, e, 6, 11, 25);
+            let ch_efg = ch(self, e, f, g);
+            let temp1 = self
+                .add_many_u32(&[h, big_s1_e, ch_efg, k256[i], w[i & 0xf]])
+                .0;
+
+            let big_s0_a = big_sigma(self, a, 2, 13, 22);
+            let maj_abc = maj(self, a, b, c);
+            let temp2 = self.add_u32_lo(big_s0_a, maj_abc);
+
+            h = g;
+            g = f;
+            f = e;
+            e = self.add_u32_lo(d, temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = self.add_u32_lo(temp1, temp2); // add_many_u32 of 3 elements is the same
+        }
+
+        // Add the compressed chunk to the current hash value
+        state[0] = self.add_u32_lo(state[0], a);
+        state[1] = self.add_u32_lo(state[1], b);
+        state[2] = self.add_u32_lo(state[2], c);
+        state[3] = self.add_u32_lo(state[3], d);
+        state[4] = self.add_u32_lo(state[4], e);
+        state[5] = self.add_u32_lo(state[5], f);
+        state[6] = self.add_u32_lo(state[6], g);
+        state[7] = self.add_u32_lo(state[7], h);
+        
+        // round 2
+        let zero = self.constant_u32(0);
+        let cx80 = self.constant_u32(0x80000000);
+        let c512 = self.constant_u32(512);
+
+        let mut w: [U32Target; 16] = [
+            cx80,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            c512,
+        ];
+
+        // Initialize working variables to current hash value
+        let mut a = state[0];
+        let mut b = state[1];
+        let mut c = state[2];
+        let mut d = state[3];
+        let mut e = state[4];
+        let mut f = state[5];
+        let mut g = state[6];
+        let mut h = state[7];
+
+        for i in 0..64 {
+            // Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array
+            if i >= 16 {
+                let s0 = sigma(self, w[(i + 1) & 0xf], 7, 18, 3);
+                let s1 = sigma(self, w[(i + 14) & 0xf], 17, 19, 10);
+                w[i & 0xf] = self.add_many_u32(&[s0, s1, w[(i + 9) & 0xf], w[i & 0xf]]).0;
+            }
+
+            // Compression function main loop
+            let big_s1_e = big_sigma(self, e, 6, 11, 25);
+            let ch_efg = ch(self, e, f, g);
+            let temp1 = self
+                .add_many_u32(&[h, big_s1_e, ch_efg, k256[i], w[i & 0xf]])
+                .0;
+
+            let big_s0_a = big_sigma(self, a, 2, 13, 22);
+            let maj_abc = maj(self, a, b, c);
+            let temp2 = self.add_u32_lo(big_s0_a, maj_abc);
+
+            h = g;
+            g = f;
+            f = e;
+            e = self.add_u32_lo(d, temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = self.add_u32_lo(temp1, temp2); // add_many_u32 of 3 elements is the same
+        }
+
+        // Add the compressed chunk to the current hash value
+        state[0] = self.add_u32_lo(state[0], a);
+        state[1] = self.add_u32_lo(state[1], b);
+        state[2] = self.add_u32_lo(state[2], c);
+        state[3] = self.add_u32_lo(state[3], d);
+        state[4] = self.add_u32_lo(state[4], e);
+        state[5] = self.add_u32_lo(state[5], f);
+        state[6] = self.add_u32_lo(state[6], g);
+        state[7] = self.add_u32_lo(state[7], h);
+        state
+    }
 }
 
 #[cfg(test)]
@@ -255,8 +411,118 @@ mod tests {
     use sha2::{Digest, Sha256};
 
     use crate::hash::sha256::{CircuitBuilderHashSha2, WitnessHashSha2};
-    use crate::hash::CircuitBuilderHash;
+    use crate::hash::{CircuitBuilderHash, WitnessHash};
+    use crate::hash::merkle_utils::{Hash256};
     const SHA256_BLOCK: usize = 512;
+
+    #[test]
+    fn test_sha256_two_to_one() {
+
+        let tests = [
+            [
+              "44205ea3a71ee1cbd02eef7b084a409450c21d11a3b41769f02bb3e2dd89d5e2",
+              "8ecf785b86dd1715d4c193f280a118b82200742f102bf1e59a4a65194a126f03",
+              "a452e23aab1e4baae2e3da7c66da43954038e6505dc5b1cb24c8b5d95cf7634c"
+            ],
+            [
+              "42f584ee07afb6754770ea07fc7f498cb7200ba89eb67361a7f2564612040cd3",
+              "09e0ed078a0113619c033eec41b65e3168394dc377998bc13481b5f1942f7119",
+              "2096622ca7f5aeda8d4c9a9cd4523e1bb9ea09e661f092f515c0c2cbaadcc2c6"
+            ],
+            [
+              "8560e7d4c6e014b01b70bf5e1e2ffaa1e4115c9d21eb685b796b172872b71150",
+              "3d38f5e8fc6c4612f27932b009bea0fd41a99c30af7a14a1e5316d9bbd5a4df6",
+              "eab6fce22d0679c304d7419cf0746552921b31245d715171a5ec7c9caf81f084"
+            ],
+            [
+              "7c909a4734e36fd67e11cd97a9a4222795672690f3eb081a2dd43a413ba6490c",
+              "39a08a837c5bfef00ebb6e3b72f7fc5a8275f13fb5d5a86f03541ebf5ee8edec",
+              "f537f1e2ac17a2af3524b7e3fc81ca88adcee65906236dab22250e071924e527"
+            ],
+            [
+              "130151db7ac8036300c80c58a37de8119719ce60600b6e009d09df3a71d5f741",
+              "a6bf923dbbcaae29701d82e0a1492ffe388aa14bd3e6ffbfa834aa9b23ad154a",
+              "e70822e27d35acff57fc210d451aba171285025ac2fa77911e893427a8430b25"
+            ],
+            [
+              "9992ff1b7ff438d5132b2b5ddd875c10ca62bcb46f681ef228548abdcd6db5c1",
+              "4080eca86a5ea164518fc7426dc793ce5c9f95831bc8a97b2f06bc53722c78bb",
+              "1bdbe0e67971989362b44c66f7ff26eea7d6c7f5f791d91e96bfa46a6934b97b"
+            ],
+            [
+              "2a6f3577676eb6493d62268cf402f39f432490f8ca64d2323eab7ffb8fa5e239",
+              "a004b81f69f9b6694fad09f0193e9120789d4e870681f436a97a2eef9089a3e2",
+              "3dd8900540834a3fe28407796f128a21dd4c947b6b991ed14d6167ae4fc29cc3"
+            ],
+            [
+              "7b4e5361bddc8029f76c3fead78e0a0a49e02dd40666cdff03ea40609de3c8d9",
+              "bf7b76a80a3a70151640263f13bb62f72d66f0075f03b64e51aaec781b36d8c9",
+              "809cf278ede0e210b29e7ce57b12a058d5d1f78be62a16df0c301995be7e7a5d"
+            ],
+            [
+              "a52ae0c843df054f6a9489a743f293a74b7fe21f14bff5d35e9c9ec4fe336522",
+              "e3e6379804432520b7eba2a7b46d0b016a4025f32da7cb8aa0003aaf57dab15c",
+              "f56647e8f500efaafe8aaaf9a90b142685896cba145a06a6bc9853d9765079b8"
+            ],
+            [
+              "386d9d8e6851f030ac2f510b6a8ebcc2f00e16a9cc7b7707d7d65f8a95ae82f3",
+              "bb2b56422cd46210f5ab0c53527e8bf7ef71ad723a77a2cba0d990da15c9bde8",
+              "d4d029cc7fbc6eba897d5659bb4d0298f9d3609c383526de67ab15b26fa95ad2"
+            ],
+            [
+              "6e326b458d8bbef8b5a592e939d8bfa2dffb769a5f616034fb0cbf1267d4a600",
+              "d5b60f7116771c9033a32bd2ccd22912d97bd3cf30d526fdcaff9f1bc9453397",
+              "6c915b5095aca9df36491281c04a4f127b9fd81b4362742f07314d945b44582a"
+            ],
+            [
+              "4af3eaf1108b48e0df66988876570f2044db09a0cad061da7d2448871fc52cb6",
+              "cf5c4c57391fa60fbd613b2bdd5ddb5da9435239d073f2cdd265d0788e0b9cec",
+              "54a342f852b7d41a5aab4a6a73cfc9adbc3b5fc42303627dbd604eede98e334f"
+            ]
+          ];
+
+        // build circuit once
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let left_target = builder.add_virtual_hash256_target();
+        let right_target = builder.add_virtual_hash256_target();
+        let expected_output_target = builder.add_virtual_hash256_target();
+        let output_target = builder.two_to_one_sha256(left_target, right_target);
+        builder.connect_hash256(output_target, expected_output_target);
+        
+        let num_gates = builder.num_gates();
+        // let copy_constraints = builder.copy_constraints.len();
+        let copy_constraints = "<private>";
+        let data = builder.build::<C>();
+        println!(
+            "sha256_two_to_one num_gates={}, copy_constraints={}, quotient_degree_factor={}",
+            num_gates, copy_constraints, data.common.quotient_degree_factor
+        );
+
+
+
+        for t in tests {
+            let left = Hash256::from_str(t[0]).unwrap();
+            let right = Hash256::from_str(t[1]).unwrap();
+            let expected_output = Hash256::from_str(t[2]).unwrap();
+
+
+
+            // test circuit
+            let mut pw = PartialWitness::new();
+            pw.set_hash256_target(&left_target, &left.0);
+            pw.set_hash256_target(&right_target, &right.0);
+            pw.set_hash256_target(&expected_output_target, &expected_output.0);
+            
+            let proof = data.prove(pw).unwrap();
+            // println!("sha256 proof.public_inputs =\n{:08x?}", proof.public_inputs);
+            assert!(data.verify(proof).is_ok());
+        }
+    }
 
     #[test]
     fn test_sha256_long() {

--- a/src/hash/sha256_merkle.rs
+++ b/src/hash/sha256_merkle.rs
@@ -1,0 +1,279 @@
+use plonky2::field::extension::Extendable;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::target::{BoolTarget, Target};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+
+use crate::u32::arithmetic_u32::U32Target;
+
+use super::sha256::{CircuitBuilderHashSha2, WitnessHashSha2};
+use super::{CircuitBuilderHash, Hash256Target, WitnessHash};
+
+fn select_hash256<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    bit: BoolTarget,
+    left: &Hash256Target,
+    right: &Hash256Target,
+) -> Hash256Target {
+    let a = U32Target(builder.select(bit, left[0].0, right[0].0));
+    let b = U32Target(builder.select(bit, left[1].0, right[1].0));
+    let c = U32Target(builder.select(bit, left[2].0, right[2].0));
+    let d = U32Target(builder.select(bit, left[3].0, right[3].0));
+    let e = U32Target(builder.select(bit, left[4].0, right[4].0));
+    let f = U32Target(builder.select(bit, left[5].0, right[5].0));
+    let g = U32Target(builder.select(bit, left[6].0, right[6].0));
+    let h = U32Target(builder.select(bit, left[7].0, right[7].0));
+
+    [a, b, c, d, e, f, g, h]
+}
+
+pub fn compute_merkle_root<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    index_bits: &Vec<BoolTarget>,
+    value: Hash256Target,
+    siblings: &Vec<Hash256Target>,
+) -> Hash256Target {
+    let mut current = value;
+    for (i, sibling) in siblings.iter().enumerate() {
+        let bit = index_bits[i];
+
+        let left = select_hash256(builder, bit, sibling, &current);
+        let right = select_hash256(builder, bit, &current, sibling);
+        current = builder.two_to_one_sha256(left, right);
+    }
+    current
+}
+
+pub struct MerkleProofSha256Gadget {
+    pub root: Hash256Target,
+    pub value: Hash256Target,
+    pub siblings: Vec<Hash256Target>,
+    pub index: Target,
+}
+
+impl MerkleProofSha256Gadget {
+    pub fn add_virtual_to<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        height: usize,
+    ) -> Self {
+        let siblings: Vec<Hash256Target> = (0..height)
+            .map(|_| builder.add_virtual_hash256_target())
+            .collect();
+
+        let value = builder.add_virtual_hash256_target();
+        let index = builder.add_virtual_target();
+        let index_bits = builder.split_le(index, height);
+        let root = compute_merkle_root(builder, &index_bits, value, &siblings);
+
+        Self {
+            root,
+            value,
+            siblings,
+            index,
+        }
+    }
+
+    pub fn set_witness<F: RichField, W: WitnessHashSha2<F>>(
+        &self,
+        witness: &mut W,
+        index: u64,
+        value: &[u8; 32],
+        siblings: &Vec<[u8; 32]>,
+    ) {
+        witness.set_hash256_target(&self.value, value);
+        witness.set_target(self.index, F::from_noncanonical_u64(index));
+        for (i, sibling) in self.siblings.iter().enumerate() {
+            witness.set_hash256_target(sibling, &siblings[i]);
+        }
+    }
+}
+
+pub struct DeltaMerkleProofSha256Gadget {
+    pub old_root: Hash256Target,
+    pub old_value: Hash256Target,
+
+    pub new_root: Hash256Target,
+    pub new_value: Hash256Target,
+
+    pub siblings: Vec<Hash256Target>,
+    pub index: Target,
+}
+
+impl DeltaMerkleProofSha256Gadget {
+    pub fn add_virtual_to<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        height: usize,
+    ) -> Self {
+        let siblings: Vec<Hash256Target> = (0..height)
+            .map(|_| builder.add_virtual_hash256_target())
+            .collect();
+
+        let old_value = builder.add_virtual_hash256_target();
+        let new_value = builder.add_virtual_hash256_target();
+        let index = builder.add_virtual_target();
+        let index_bits = builder.split_le(index, height);
+        let old_root = compute_merkle_root(builder, &index_bits, old_value, &siblings);
+        let new_root = compute_merkle_root(builder, &index_bits, new_value, &siblings);
+
+        Self {
+            old_root,
+            old_value,
+            new_root,
+            new_value,
+            siblings,
+            index,
+        }
+    }
+
+    pub fn set_witness<F: RichField, W: WitnessHashSha2<F>>(
+        &self,
+        witness: &mut W,
+        index: u64,
+        old_value: &[u8; 32],
+        new_value: &[u8; 32],
+        siblings: &Vec<[u8; 32]>,
+    ) {
+        witness.set_hash256_target(&self.old_value, old_value);
+        witness.set_hash256_target(&self.new_value, new_value);
+        witness.set_target(self.index, F::from_noncanonical_u64(index));
+        for (i, sibling) in self.siblings.iter().enumerate() {
+            witness.set_hash256_target(sibling, &siblings[i]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::hash::{CircuitBuilderHash, WitnessHash};
+    use crate::hash::merkle_utils::{MerkleProof256, DeltaMerkleProof256};
+    use crate::hash::sha256_merkle::{MerkleProofSha256Gadget, DeltaMerkleProofSha256Gadget};
+    use plonky2::iop::witness::PartialWitness;
+    use plonky2::plonk::circuit_builder::CircuitBuilder;
+    use plonky2::plonk::circuit_data::CircuitConfig;
+    use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    /*
+    use super::super::merkle_utils::MerkleHasher;
+    use crate::hash::merkle_utils::Hash256;
+    use sha2::{Digest, Sha256};
+
+    pub struct Sha256Hasher {}
+    impl Sha256Hasher {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl MerkleHasher<Hash256> for Sha256Hasher {
+        fn two_to_one(&self, left: &Hash256, right: &Hash256) -> Hash256 {
+            let mut hasher = Sha256::new();
+            hasher.update(left.0);
+            hasher.update(right.0);
+            let result = hasher.finalize();
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(&result[..]);
+            Hash256(hash)
+        }
+    }
+    */
+
+    #[test]
+    fn test_verify_small_merkle_proof() {
+        // build circuit once
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+
+        let merkle_proof_gadget = MerkleProofSha256Gadget::add_virtual_to(&mut builder, 3);
+        let expected_root_target = builder.add_virtual_hash256_target();
+        builder.connect_hash256(expected_root_target, merkle_proof_gadget.root);
+        let num_gates = builder.num_gates();
+        // let copy_constraints = builder.copy_constraints.len();
+        let data = builder.build::<C>();
+        println!(
+            "circuit num_gates={}, quotient_degree_factor={}",
+            num_gates, data.common.quotient_degree_factor
+        );
+
+        let mut pw = PartialWitness::new();
+        let proof_serialized = r#"
+        {
+          "root": "7e286a6721a66675ea033a4dcdec5abbdc7d3c81580e2d6ded7433ed113b7737",
+          "siblings": [
+            "0000000000000000000000000000000000000000000000000000000000000007",
+            "ce44a8ee02db1a76906b0e9fd753893971c4db9a2341b0049d61f7fcd2a60adf",
+            "81b1e323f0e91a785dfd155817e09949a7d66fe8fdc4f31f39530845e88ab63c"
+          ],
+          "index": 2,
+          "value": "0000000000000000000000000000000000000000000000000000000000000003"
+        }
+        "#;
+        let proof: MerkleProof256 =
+            serde_json::from_str::<MerkleProof256>(proof_serialized).unwrap();
+        merkle_proof_gadget.set_witness_from_proof(&mut pw, &proof);
+        pw.set_hash256_target(&expected_root_target, &proof.root.0);
+
+        let start_time = std::time::Instant::now();
+
+        let proof = data.prove(pw).unwrap();
+        let duration_ms = start_time.elapsed().as_millis();
+        println!("proved in {}ms", duration_ms);
+        assert!(data.verify(proof).is_ok());
+    }
+
+
+    #[test]
+    fn test_verify_small_delta_merkle_proof() {
+      // build circuit once
+      const D: usize = 2;
+      type C = PoseidonGoldilocksConfig;
+      type F = <C as GenericConfig<D>>::F;
+
+      let config = CircuitConfig::standard_recursion_config();
+      let mut builder = CircuitBuilder::<F, D>::new(config);
+
+      let merkle_proof_gadget = DeltaMerkleProofSha256Gadget::add_virtual_to(&mut builder, 3);
+      let expected_old_root_target = builder.add_virtual_hash256_target();
+      let expected_new_root_target = builder.add_virtual_hash256_target();
+      builder.connect_hash256(expected_old_root_target, merkle_proof_gadget.old_root);
+      builder.connect_hash256(expected_new_root_target, merkle_proof_gadget.new_root);
+      
+      let num_gates = builder.num_gates();
+      // let copy_constraints = builder.copy_constraints.len();
+      let data = builder.build::<C>();
+      println!(
+          "circuit num_gates={}, quotient_degree_factor={}",
+          num_gates, data.common.quotient_degree_factor
+      );
+
+      let mut pw = PartialWitness::new();
+      let proof_serialized = r#"
+      {
+        "index": 5,
+        "siblings": [
+          "0000000000000000000000000000000000000000000000000000000000000004",
+          "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+          "2f4d3e941b602c50347af3f5c809a28737c27c7ce460e77b10739875ef957aa7"
+        ],
+        "old_root": "a5a22d441141c6bfdeaa816a93cdcc879e893e47d4e450c47f65f0cfa65e237c",
+        "old_value": "0000000000000000000000000000000000000000000000000000000000000000",
+        "new_value": "0000000000000000000000000000000000000000000000000000000000000002",
+        "new_root": "c7d129a209e40611a4cc44632f38c6fd577b4329c27dae5a651d2f67c715a618"
+      }
+      "#;
+      let proof =
+          serde_json::from_str::<DeltaMerkleProof256>(proof_serialized).unwrap();
+      merkle_proof_gadget.set_witness_from_proof(&mut pw, &proof);
+      pw.set_hash256_target(&expected_old_root_target, &proof.old_root.0);
+      pw.set_hash256_target(&expected_new_root_target, &proof.new_root.0);
+
+      let start_time = std::time::Instant::now();
+
+      let proof = data.prove(pw).unwrap();
+      let duration_ms = start_time.elapsed().as_millis();
+      println!("proved in {}ms", duration_ms);
+      assert!(data.verify(proof).is_ok());
+    }
+}


### PR DESCRIPTION
Description of changes:
1. Added a new target type for 256 bit hashes, `Hash256Target`
2. Added `two_to_one_sha256(x: Hash256Target, y: Hash256Target) -> Hash256Target` to CircuitBuilderHashSha2 which hashes two Hash256Targets and returns the result as a single Hash256Target
3. Added `connect_hash256(x: Hash256Target, y: Hash256Target)` to CircuitBuilderHash for 256-bit hash related constraints
4. Added `MerkleProofSha256Gadget` which can be used to verify sha256 merkle proofs
5. Added `DeltaMerkleProofSha256Gadget` which can be used to verify sha256 delta merkle proofs
6. Added tests for MerkleProofSha256Gadget, DeltaMerkleProofSha256Gadget, and two_to_one_sha256
7. Added optional serde serializable structs: Hash256, DeltaMerkleProof, and MerkleProof (anything that needs serde is quarantined in merkle_utils.rs, so it would be easy to put this behind a feature flag if serde is made an optional dependency in the future)

Reason for changes (Numbers correspond to the index in description):
1. It is useful to have a fixed length output of 8 U32Target so we can use it for keccak/sha256 in the same use cases that the HashOut is used for poseidon hashes (HashOut only gives us 63*4 =252 bits)
2. It is often necessary to link the results of multiple hash results together (such as in the case of verifying merkle proof), hence there is a need for a two_to_one hash function where the output is returned.
3. It is useful to link two hash256's for operations like verifying merkle proofs
4. Zero Knowledge circuits frequently need to verify merkle proofs when handling external data
5. Zero Knowledge circuits frequently need to verify delta merkle proofs when proving individual changes to external data
6. Test coverage for common use case gadgets
7. Useful for processing data from the web/merkle databases/testing
